### PR TITLE
fix toogling multiline field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.1] - 2022/03/25
+
+## Fixed
+
+- Toggling build_url and code_base
+
 ## [2.2.0] - 2022/01/10
 
 ## Added

--- a/adaptavist/_helper.py
+++ b/adaptavist/_helper.py
@@ -47,9 +47,10 @@ def update_field(current_values: List[Any], request_data: Dict[str, Any], key: s
 
 def update_multiline_field(current_content: str, request_data: Dict[str, Any], key: str, new_values: List[str]) -> None:
     """Update a multiline custom field (html) with additional or new values."""
-    new_content = "" if new_values and new_values[0] == "-" else current_content
     if new_values and new_values[0] == "-":
-        new_values = new_values[1:]
-    combined_values = "<br>".join(value for value in new_values if value not in new_content)
+        combined_values = "<br>".join(list(dict.fromkeys(new_values[1:]).keys()))
+    else:
+        new_values.insert(0, current_content)
+        combined_values = "<br>".join(list(dict.fromkeys(new_values).keys()))
     if current_content != combined_values:
         request_data.setdefault("customFields", {})[key] = combined_values


### PR DESCRIPTION
Currently if you set the same build_url or code_base_url it is overwritten with an empty value. Next time it is set again, next time deleted and so on.

This MR fixes this.