### PR TITLE
Adds compatibility with older tm4j api

### DIFF
--- a/adaptavist/adaptavist.py
+++ b/adaptavist/adaptavist.py
@@ -714,7 +714,7 @@ class Adaptavist:
             return []
         results = request.json()
         for result in results:
-            result["scriptResults"] = sorted(result["scriptResults"], key=lambda result: result["index"])
+            result["scriptResults"] = sorted(result["scriptResults"], key=lambda result: result.get("index", 0))
         return results
 
     def create_test_results(


### PR DESCRIPTION
Older TM4J API do not have index key in the
/testrun/{test_run_key}/testresults endpoint