### PR TITLE
Fix CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: "main"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: "main"

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout sources
-      uses: actions/checkout@v3
+      uses: actions/checkout@v3.5.2
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v4.6.0
       with:
         python-version: 3.8
     - name: Check formatting
@@ -22,9 +22,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout sources
-      uses: actions/checkout@v3
+      uses: actions/checkout@v3.5.2
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v4.6.0
       with:
         python-version: 3.8
     - name: Lint with flake8
@@ -44,17 +44,36 @@ jobs:
         python -m pip install mypy types-requests
         mypy --ignore-missing-imports adaptavist
 
+  test36:
+    name: Test with Python 3.6
+    runs-on: ubuntu-20.04
+    steps:
+    - name: Checkout sources
+      uses: actions/checkout@v3.5.2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4.6.0
+      with:
+        python-version: 3.6
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install pytest-cov
+        python -m pip install .[test]
+    - name: Test with pytest
+      run: |
+        pytest --cov=adaptavist
+
   test:
     name: Test with Python ${{ matrix.python-version }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
     steps:
     - name: Checkout sources
-      uses: actions/checkout@v3
+      uses: actions/checkout@v3.5.2
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v4.6.0
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -50,7 +50,7 @@ jobs:
     steps:
     - name: Checkout sources
       uses: actions/checkout@v3.5.2
-    - name: Set up Python ${{ matrix.python-version }}
+    - name: Set up Python 3.6
       uses: actions/setup-python@v4.6.0
       with:
         python-version: 3.6

--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -8,9 +8,9 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v3.5.2
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v4.6.0
       with:
         python-version: "3.8"
     - name: Install dependencies

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,14 +1,14 @@
 repos:
 -   repo: https://github.com/psf/black
-    rev: '22.3.0'
+    rev: '23.1.0'
     hooks:
     - id: black
 -   repo: https://github.com/pycqa/isort
-    rev: '5.9.3'
+    rev: '5.12.0'
     hooks:
         - id: isort
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: 'v4.0.1'
+    rev: 'v4.4.0'
     hooks:
         - id: end-of-file-fixer
         - id: trailing-whitespace

--- a/tests/test_adaptavist.py
+++ b/tests/test_adaptavist.py
@@ -13,6 +13,7 @@ from . import load_fixture
 
 
 class TestAdaptavist:
+    """Test the Adaptavist module."""
 
     _jira_url = "mock://jira"
     _adaptavist_api_url = f"{_jira_url}/rest/atm/1.0"


### PR DESCRIPTION
Python 3.6 is no longer supported by the ubunut-latest image. Additionally, pre-commit actions were outdated. To prevent that in future, a dependabot was added. 