### PR TITLE
Fix ValueError in get_test_result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.3] - 2023/09/12
+
+### Fixed
+
+- get_test_result does not raise in case there are no results
+
 ## [2.3.2] - 2023/06/21
 
 ### Fixed

--- a/adaptavist/adaptavist.py
+++ b/adaptavist/adaptavist.py
@@ -771,12 +771,10 @@ class Adaptavist:
         :returns: Test result
         """
         response = self.get_test_results(test_run_key)
-        return (
-            max(
-                (item for item in response if item["testCaseKey"] == test_case_key),
-                key=lambda item: item["id"],
-            )
-            or {}
+        return max(
+            (item for item in response if item["testCaseKey"] == test_case_key),
+            key=lambda item: item["id"],
+            default={},
         )
 
     def create_test_result(


### PR DESCRIPTION
The [tests of pytest-adaptavist](https://github.com/devolo/pytest-adaptavist/actions/runs/6155637299/job/16702851661) uncovered a bug, that get_test_result raises a ValueError in case that no results exist, yet. This MR fixes that.

